### PR TITLE
provide a valid listing for compound cube

### DIFF
--- a/src/cls/BI/Model/CompoundCube/CityRainfall.cls
+++ b/src/cls/BI/Model/CompoundCube/CityRainfall.cls
@@ -12,6 +12,7 @@ displayName="CompoundCube/CityRainfall"
 owner="_SYSTEM"
 sourceClass="BI.Study.CityRainfall"
 countMeasureName="Rainfall Observation Count"
+defaultListing="CompoundListing" 
  >
 
 <dimension name="BirthD" displayName="DateD" 
@@ -57,8 +58,12 @@ displayName="Avg Monthly Rainfall Inches"
 sourceProperty="InchesOfRain" 
  aggregate="AVG"/>
 
-<listing name="Details" displayName="Details" 
+<listing name="RainfallDetailListing" displayName="RainfallDetails" 
   fieldList='City->Name as "City",MonthAndYear as "Date",InchesOfRain as "Inches of Rain"'>
+</listing>
+
+<listing name="CompoundListing"
+  fieldList='City->%ID as "CityID",City->Name as "CityName",City->PostalCode as "PostalCode"'>
 </listing>
 
 </cube>

--- a/src/cls/BI/Model/CompoundCube/Doctors.cls
+++ b/src/cls/BI/Model/CompoundCube/Doctors.cls
@@ -16,6 +16,7 @@ sourceClass="BI.Study.Doctor"
 nullReplacement="None"
  disabled="false"
  countMeasureName="Doctor Count"
+ defaultListing="CompoundListing"
 >
 
 <dimension name="DocD" displayName="DocD" 
@@ -74,8 +75,12 @@ displayName="Avg Patients Per Week"
 sourceProperty="PatientsPerWeek" 
  aggregate="AVG"/>
  
-<listing name="Details" displayName="Details" 
+<listing name="DoctorDetailListing" displayName="DoctorDetails" 
   fieldList='FirstName as "First Name",LastName as "Last Name",DoctorType as "Doctor Type",DoctorGroup as "Doctor Group",PatientsPerWeek as "Patients Per Week",MainCity->Name AS "Main City"'>
+</listing>
+
+<listing name="CompoundListing"
+  fieldList='MainCity->%ID as "CityID",MainCity->Name as "CityName",MainCity->PostalCode as "PostalCode"'>
 </listing>
 
 </cube>

--- a/src/cls/BI/Model/CompoundCube/Patients.cls
+++ b/src/cls/BI/Model/CompoundCube/Patients.cls
@@ -16,6 +16,7 @@ sourceClass="BI.Study.Patient"
 nullReplacement="None"
 disabled="false"
 countMeasureName="Patient Count"
+defaultListing="CompoundListing"
 >
 
 <dimension name="BirthD" displayName="BirthD" type="time" 
@@ -88,9 +89,12 @@ sourceExpression='##class(BI.Model.PatientsCube).GetAllergyCount(%source.%ID)'
 sourceProperty="TestScore" 
  aggregate="AVG"/>
 
-<listing name="Details" displayName="Details" 
+<listing name="PatientDetailListing" displayName="PatientDetails" 
  fieldList='PatientID,Age,Gender,HomeCity->Name AS "Home City",TestScore AS "Test Score"'
   orderBy="Age,Gender" /> 
+
+<listing name="CompoundListing"
+  fieldList='HomeCity->%ID as "CityID",HomeCity->Name as "CityName",HomeCity->PostalCode as "PostalCode"' />
 
 </cube>
 }


### PR DESCRIPTION
The previous listings defined for CompoundCubes/Doctors, CompoundCubes/Patients, and CompoundCubes/CityRainfall did not have identical column specs, as required in order for listings to be run on the CompoundCubes/CompoundCube subject area. This produced an error relating to the SQL syntax when trying to view a listing on that subject area. The new CompoundListing in each of the three cubes should correct this, though I have encountered errors reading "Query must be prepared prior to calling ExecuteAxes" (which may be an IRIS bug) if I view a listing on the CompoundCubes/CompoundCube subject area after selecting some, but not all, members of a level on rows or columns.